### PR TITLE
Sharing IsUserVerified

### DIFF
--- a/ExampleApp/Assets/Editor/Arbiter/Arbiter/Arbiter.m
+++ b/ExampleApp/Assets/Editor/Arbiter/Arbiter/Arbiter.m
@@ -186,7 +186,7 @@
             NSString *postalCode = [geoCodeResponse objectForKey:@"postalCode"];
             [self.user setObject:postalCode forKey:@"postal_code"];
             
-            if ( [[self.user objectForKey:@"agreed_to_terms"] boolValue] == true && [[self.user objectForKey:@"location_approved"] boolValue] == true ) {
+            if ([self isUserVerified]) {
                 handler(@{@"user": self.user,
                           @"success": @"true"});
             } else if ( [[self.user objectForKey:@"agreed_to_terms"] boolValue] == false && [[self.user objectForKey:@"location_approved"] boolValue] == false ) {
@@ -238,6 +238,15 @@
             locationCallback(@{@"success": @"true",
                            @"postalCode": [self.user objectForKey:@"postal_code"]});
         }
+    }
+}
+
+- (bool)isUserVerified
+{
+    if (self.user != nil && [[self.user objectForKey:@"agreed_to_terms"] boolValue] == true && [[self.user objectForKey:@"location_approved"] boolValue] == true ) {
+        return true;
+    } else {
+        return false;
     }
 }
 

--- a/ExampleApp/Assets/Editor/Arbiter/Arbiter/ArbiterCWrapper.m
+++ b/ExampleApp/Assets/Editor/Arbiter/Arbiter/ArbiterCWrapper.m
@@ -109,6 +109,12 @@ void _verifyUser()
     }];
 }
 
+bool _isUserVerified()
+{
+    checkForArbiterGameObject();
+    return [arbiter isUserVerified];
+}
+
 void _getWallet()
 {
     checkForArbiterGameObject();

--- a/ExampleApp/Assets/Game/Entrypoint.cs
+++ b/ExampleApp/Assets/Game/Entrypoint.cs
@@ -29,7 +29,6 @@ public class Entrypoint : MonoBehaviour {
 				Arbiter.LoginWithGameCenter( VerificationStep );
 			} else {
 				Debug.LogError( "Could not authenticate to Game Center! Calling Arbiter.Login()" );
-//				Arbiter.Login ( VerificationStep );
 				Arbiter.LoginAsAnonymous( VerificationStep );
 			}
 		};
@@ -39,7 +38,7 @@ public class Entrypoint : MonoBehaviour {
 
     void VerificationStep() {
     
-    	Debug.Log ("Arbiter.IsAuthenticated" + Arbiter.IsAuthenticated);
+    	Debug.Log ("Arbiter.IsAuthenticated? " + Arbiter.IsAuthenticated);
         Debug.Log( "Hello, " + Arbiter.Username + "!" );
         Debug.Log( "Have you verified your age & location yet? " + Arbiter.IsVerified );
 

--- a/ExampleApp/Assets/Plugins/Arbiter/Arbiter.cs
+++ b/ExampleApp/Assets/Plugins/Arbiter/Arbiter.cs
@@ -17,7 +17,7 @@ public partial class Arbiter : MonoBehaviour
 	public static string    UserId                      { get { return user.Id; } }
 	public static string    Username                    { get { return user.Name; } }
 	public static string	AccessToken				  	{ get { return user.Token; }}
-	public static bool      IsVerified                  { get { return verified == VerificationStatus.Verified; } }
+	public static bool		IsVerified					{ get { return ArbiterBinding.IsUserVerified(); } }
 	public static bool		AgreedToTerms				{ get { return user.AgreedToTerms; } }
 	public static bool		LocationApproved			{ get { return user.LocationApproved; } }
 	public static string    Balance                     { get { return wallet.Balance; } }
@@ -110,14 +110,10 @@ public partial class Arbiter : MonoBehaviour
 	public static void VerifyUser( Action done ) {
 		ArbiterBinding.VerifyUserCallback parse = ( responseUser ) => {
 			user = responseUser;
-			if( responseUser.AgreedToTerms && responseUser.LocationApproved ) {
-				verified = VerificationStatus.Verified;
-			}
 			if( done != null ) {
 				done();
 			}
 		};
-		verified = VerificationStatus.Unverified;
 		ArbiterBinding.VerifyUser( parse, verifyUserErrorHandler );
 	}
 	
@@ -135,8 +131,8 @@ public partial class Arbiter : MonoBehaviour
 	
 	public static void GetWallet() {
 		if( user == null )
-			Debug.LogWarning( "Cannot get an Arbiter Wallet without first logging in. Did you call Arbiter.Initialize()?" );
-		else if( verified == VerificationStatus.Unknown )
+			Debug.LogWarning( "Cannot get an Arbiter Wallet without first logging in" );
+		else if( !IsVerified )
 			Debug.LogWarning( "This user has not yet been verified and cannot query an Arbiter wallet. Did you call Arbiter.VerifyUser()?" );
 		
 		queryWalletIfAble( null );
@@ -144,8 +140,8 @@ public partial class Arbiter : MonoBehaviour
 	
 	private static void queryWalletIfAble( Action callback ) {
 		walletSuccessCallback = callback;
-		
-		if( user == null || verified != VerificationStatus.Verified ) {
+
+		if( user == null || !IsVerified ) {
 			if( walletSuccessCallback != null )
 				walletSuccessCallback();
 			return;
@@ -305,7 +301,6 @@ public partial class Arbiter : MonoBehaviour
 	
 	private static void parseLoginResponse( User responseUser, bool responseVerified, Wallet responseWallet, Action done ) {
 		user = responseUser;
-		verified = responseVerified? VerificationStatus.Verified : VerificationStatus.Unknown;
 		wallet = responseWallet != null? responseWallet : new Wallet();
 		setupPollers();
 		walletPoller.SetAction( queryWalletIfAble );
@@ -318,8 +313,6 @@ public partial class Arbiter : MonoBehaviour
 	private static Poller walletPoller;
 	private static Poller tournamentPoller;
 	private static User user;
-	private enum VerificationStatus { Unknown, Unverified, Verified };
-	private static VerificationStatus verified = VerificationStatus.Unknown;
 	private static Wallet wallet;
 	private static List<Tournament> initializingTournaments;
 	private static List<Tournament> inProgressTournaments;
@@ -339,4 +332,5 @@ public partial class Arbiter : MonoBehaviour
 	#if UNITY_IOS
 	private static ArbiterBinding.ErrorHandler loginWithGameCenterErrorHandler = defaultErrorHandler;
 	#endif
+
 }

--- a/ExampleApp/Assets/Plugins/Arbiter/ArbiterBinding.cs
+++ b/ExampleApp/Assets/Plugins/Arbiter/ArbiterBinding.cs
@@ -8,9 +8,21 @@ using SimpleJSON;
 
 
 namespace ArbiterInternal {
-	
+
 	public class ArbiterBinding : MonoBehaviour
 	{
+
+#region Shared data
+		
+		[DllImport ("__Internal")]
+		private static extern bool _isUserVerified();
+		public static bool IsUserVerified() {
+			return _isUserVerified();
+		}
+		
+#endregion
+
+
 		[DllImport ("__Internal")]
 		private static extern void _init( string gameApiKey, string accessToken );
 		private static ErrorHandler initErrorHandler;


### PR DESCRIPTION
Having the C# side of "IsUserVerified" call down to the native user object instead of caching its own version.

Next step is the whole user object and wallet (will be separate PR or an update to this one).
